### PR TITLE
Small Experimental Enhancement

### DIFF
--- a/frontend/src/components/v-summary-charts.vue
+++ b/frontend/src/components/v-summary-charts.vue
@@ -136,7 +136,6 @@
         .summary-chart__title--percentile(
           v-if="filterGroupSelection === 'groupByNone' && sortGroupSelection.includes('totalCommits')"
         ) {{ getPercentile(j) }} %
-
       .summary-chart__ramp(
         v-on:click="openTabZoomSubrange(user, $event, isGroupMerged(getGroupName(repo)))"
       )
@@ -166,10 +165,18 @@
             )
         template(v-else)
           .summary-chart__contrib(
-            v-bind:title="'Total contribution from ' + minDate + ' to ' + maxDate + ': '\
-              + user.checkedFileTypeContribution + ' lines'"
+            v-bind:title=`'Total contribution from ' + minDate + ' to ' + maxDate + ': '\
+              + user.checkedFileTypeContribution + ' lines ' \
+            + getContributionPercentile(user.checkedFileTypeContribution, repo) + '%' \
+            + " of the repo\'s total lines of code"`
           )
             .summary-chart__contrib--bar(
+              v-if="contributionPercentageShown",
+              v-for="width in getContributionBars(user.checkedFileTypeContribution)",
+              v-bind:style="{ width: getContributionPercentile(user.checkedFileTypeContribution, repo) + '%' }"
+            )
+            .summary-chart__contrib--bar(
+              v-else,
               v-for="width in getContributionBars(user.checkedFileTypeContribution)",
               v-bind:style="{ width: width+'%' }"
             )
@@ -185,7 +192,7 @@ export default {
   components: {
     vRamp,
   },
-  props: ['checkedFileTypes', 'filtered', 'avgContributionSize', 'filterBreakdown',
+  props: ['checkedFileTypes', 'filtered', 'avgContributionSize', 'filterBreakdown', 'contributionPercentageShown',
       'filterGroupSelection', 'filterTimeFrame', 'filterSinceDate', 'filterUntilDate', 'isMergeGroup',
       'minDate', 'maxDate', 'filterSearch', 'sortGroupSelection'],
   data() {
@@ -441,6 +448,10 @@ export default {
         return (Math.round(((index + 1) * 1000) / this.filtered[0].length) / 10).toFixed(1);
       }
       return (Math.round(((index + 1) * 1000) / this.filtered.length) / 10).toFixed(1);
+    },
+
+    getContributionPercentile(personalContribution, repo) {
+      return ((personalContribution / this.getGroupTotalContribution(repo)) * 100).toFixed(2);
     },
 
     getGroupName(group) {

--- a/frontend/src/views/v-authorship.vue
+++ b/frontend/src/views/v-authorship.vue
@@ -110,7 +110,10 @@
             .tooltip(v-show="!file.active")
               font-awesome-icon(icon="caret-right", fixed-width)
               span.tooltip-text Click to show file details
-            span {{ i + 1 }}. &nbsp;&nbsp; {{ file.path }} &nbsp;
+            .tooltip
+              span {{ i + 1 }}. &nbsp;&nbsp; {{ file.path }} &nbsp;
+              span.tooltip-text(v-show="file.active") This is the file path. Click to hide file details
+              span.tooltip-text(v-show="!file.active") This is the file path. Click to show file details
           span.icons
             a(
               v-bind:href="getHistoryLink(file)", target="_blank"

--- a/frontend/src/views/v-summary.vue
+++ b/frontend/src/views/v-summary.vue
@@ -73,6 +73,16 @@
             v-bind:disabled="filterGroupSelection === 'groupByNone'"
           )
           span merge all groups
+        label.contribution-percentage-shown(
+          v-bind:style="filterGroupSelection === 'groupByRepos' ? { opacity:1.0 } : { opacity:0.5 }"
+        )
+          input.mui-checkbox(
+            type="checkbox",
+            v-model="contributionPercentageShown",
+            v-on:change="toggleBreakdown",
+            v-bind:disabled="filterGroupSelection != 'groupByRepos'"
+          )
+          span show contribution percentage bar
   .error-message-box(v-if="Object.entries(errorMessages).length")
     .error-message-box__close-button(v-on:click="dismissTab($event)") &times;
     .error-message-box__message The following issues occurred when analyzing the following repositories:
@@ -117,6 +127,7 @@
     v-bind:avg-contribution-size="avgContributionSize",
     v-bind:filter-group-selection="filterGroupSelection",
     v-bind:filter-breakdown="filterBreakdown",
+    v-bind:contribution-percentage-shown="contributionPercentageShown",
     v-bind:filter-time-frame="filterTimeFrame",
     v-bind:filter-since-date="filterSinceDate",
     v-bind:filter-until-date="filterUntilDate",
@@ -158,6 +169,7 @@ export default {
       isSortingWithinDsc: '',
       filterTimeFrame: 'commit',
       filterBreakdown: false,
+      contributionPercentageShown: false,
       tmpFilterSinceDate: '',
       tmpFilterUntilDate: '',
       hasModifiedSinceDate: window.isSinceDateProvided,


### PR DESCRIPTION
I create a "show contribution percentage bar" check box which when checked, the summary chart contribution bar's length will show the percentage of this author's contribution among the entire group. It is enabled only when the "group by" option is set to "Repo/Branch". The following graph shows the original status of the bar.
![image](https://user-images.githubusercontent.com/77223932/183250105-4fe81b94-6d65-47d4-80c7-a2180de0e8dc.png)

The following graph shows the contribution bar when the check box is checked. In the first two column, because Zhang Shi Chen is the only author contributing to the repo, Shi Chen's contribution percentage is 100%, thus the bar is a full bar. The percentage can also be seen when the mouse hover over the bar.
![checked](https://user-images.githubusercontent.com/77223932/183249674-5f9e9a09-a763-4c5f-84ea-56871394b61b.png)

This option still works when the "breakdown by file type" check box is checked. This time, each bar denotes the percentage of code in this type of file written by this author among the total lines of code in the repo.
![image](https://user-images.githubusercontent.com/77223932/183249850-c6fb3da4-16c4-47bf-b40d-9e1be058beed.png)

 